### PR TITLE
chore: Add manual deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+  workflow_call: null
+
+concurrency:
+  group: cd
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+      url: https://${{ inputs.environment }}.verify.walletconnect.com/health
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: terraform
+        uses: WalletConnect/actions/actions/deploy-terraform/@master
+        env:
+          TF_VAR_image_version: ${{ github.ref_name }}.${{ github.sha }}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+          environment: ${{inputs.environment}}
+          app-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
# Description

Adds a workflow to be able to manually trigger dev/staging deployment for any branch. 

It's not possible to trigger a `workflow_dispatch`  workflow that is not yet on `main`. 

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update