### PR TITLE
feat: Validate project IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,9 +165,10 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bouncer"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "async-trait",
  "axum",
  "axum-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.0"
 
 # Misc
+arrayvec = { version = "0.7", features = ["serde"] }
 anyhow = "1.0"
 async-trait = "0.1"
 build-info = ">=0.0.30"

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -69,6 +69,25 @@ describe('verify', () => {
       }
     })
 
+    describe('invalid project ID', () => {
+      let errMsg = "Invalid URL: ProjectId should be a hex string 32 chars long"
+      it('too short', async () => {
+        let resp = await http.get(`${url}/aaaaaaaaaa`)
+        expect(resp.status).toBe(400)
+        expect(resp.data).toBe(errMsg)
+      })
+      it('too long', async () => {
+        let resp = await http.get(`${url}/3bc51577baa09be45c84b85f13419ae8a`)
+        expect(resp.status).toBe(400)
+        expect(resp.data).toBe(errMsg)
+      })
+      it('non-hex chars', async () => {
+        let resp = await http.get(`${url}/3bc51577baa09be45c84b85f13419aez`)
+        expect(resp.status).toBe(400)
+        expect(resp.data).toBe(errMsg)
+      })
+    })
+
     it('non-existent project', async () => {
       let resp = await http.get(`${url}/3bc51577baa09be45c84b85f13419ae8`)
       expect(resp.status).toBe(404)

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Bouncer, Domain, GetAllowedDomainsError},
+    crate::{Bouncer, Domain, GetAllowedDomainsError, ProjectId},
     axum::{
         extract::{Path, State},
         response::{Html, IntoResponse, Response},
@@ -82,9 +82,9 @@ const NO_VERIFIED_DOMAINS_MSG: &str = "Project with the provided ID doesn't have
 #[instrument(level = "debug", skip(app))]
 pub async fn root(
     State(app): State<Arc<impl Bouncer>>,
-    Path(project_id): Path<String>,
+    Path(project_id): Path<ProjectId>,
 ) -> Result<impl IntoResponse, Response> {
-    let domains = app.get_allowed_domains(&project_id).await?;
+    let domains = app.get_allowed_domains(project_id).await?;
     if domains.is_empty() {
         return Err((StatusCode::NOT_FOUND, NO_VERIFIED_DOMAINS_MSG).into_response());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub use {
-    anyhow::Error, async_trait::async_trait, attestation_store::AttestationStore,
+    anyhow::Error,
+    async_trait::async_trait,
+    attestation_store::AttestationStore,
     project_registry::ProjectRegistry,
 };
 use {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 pub use {
-    anyhow::Error,
-    async_trait::async_trait,
-    attestation_store::AttestationStore,
+    anyhow::Error, async_trait::async_trait, attestation_store::AttestationStore,
     project_registry::ProjectRegistry,
 };
 use {
+    arrayvec::ArrayString,
     derive_more::{AsRef, From},
     serde::{Deserialize, Serialize},
     tap::TapFallible,
@@ -20,7 +19,7 @@ pub mod util;
 pub trait Bouncer: Send + Sync + 'static {
     async fn get_allowed_domains(
         &self,
-        project_id: &str,
+        project_id: ProjectId,
     ) -> Result<Vec<Domain>, GetAllowedDomainsError>;
 
     async fn set_attestation(&self, id: &str, origin: &str) -> Result<(), Error>;
@@ -38,6 +37,27 @@ pub enum GetAllowedDomainsError {
 
 #[derive(AsRef, Clone, Debug, From, Serialize, Deserialize)]
 pub struct Domain(String);
+
+#[derive(AsRef, Clone, Copy, Debug)]
+#[as_ref(forward)]
+pub struct ProjectId(ArrayString<32>);
+
+impl<'de> Deserialize<'de> for ProjectId {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        ArrayString::<32>::deserialize(de)
+            .ok()
+            .filter(|s| s.len() == 32 && !s.chars().any(|c| !c.is_ascii_hexdigit()))
+            .map(Self)
+            .ok_or(D::Error::custom(
+                "ProjectId should be a hex string 32 chars long",
+            ))
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectData {
@@ -61,7 +81,7 @@ impl<I: Infra> Bouncer for App<I> {
     #[instrument(level = "warn", skip(self))]
     async fn get_allowed_domains(
         &self,
-        project_id: &str,
+        project_id: ProjectId,
     ) -> Result<Vec<Domain>, GetAllowedDomainsError> {
         let mut domains = self
             .project_registry()

--- a/src/project_registry/cache/mod.rs
+++ b/src/project_registry/cache/mod.rs
@@ -1,6 +1,6 @@
 use {
     super::{ProjectData, Result},
-    crate::{async_trait, ProjectRegistry},
+    crate::{async_trait, ProjectId, ProjectRegistry},
     metrics::counter,
     tap::TapFallible as _,
     tracing::{debug, error, instrument},
@@ -18,8 +18,8 @@ fn deserialize_data(bytes: &[u8]) -> Result<Option<ProjectData>> {
 
 #[async_trait]
 pub trait Cache: Clone + Send + Sync + 'static {
-    async fn set_data(&self, project_id: &str, data: &Option<ProjectData>) -> Result<()>;
-    async fn get_data(&self, project_id: &str) -> Result<Output>;
+    async fn set_data(&self, project_id: ProjectId, data: &Option<ProjectData>) -> Result<()>;
+    async fn get_data(&self, project_id: ProjectId) -> Result<Output>;
 }
 
 // Option<Option<_>> is gross and I just shot myself in the foot with it.
@@ -52,7 +52,7 @@ where
     C: Cache,
 {
     #[instrument(level = "debug", skip(self))]
-    async fn project_data(&self, id: &str) -> Result<Option<ProjectData>> {
+    async fn project_data(&self, id: ProjectId) -> Result<Option<ProjectData>> {
         match self.cache.get_data(id).await {
             Ok(Output::Hit(data)) => {
                 debug!("get: hit");
@@ -72,13 +72,12 @@ where
         let data = self.registry.project_data(id).await?;
 
         let cache = self.cache.clone();
-        let id = id.to_string();
         let data_clone = data.clone();
 
         // Do not block on cache write.
         tokio::spawn(async move {
             let _ = cache
-                .set_data(&id, &data_clone)
+                .set_data(id, &data_clone)
                 .await
                 .tap_err(|e| error!("set: {e:?}"))
                 .tap_err(|_| counter!("project_registry_cache_write_errors", 1))

--- a/src/project_registry/cache/redis.rs
+++ b/src/project_registry/cache/redis.rs
@@ -1,6 +1,6 @@
 use {
     super::{Cache, Output, ProjectData, Result},
-    crate::{project_registry::cache, util::redis},
+    crate::{project_registry::cache, util::redis, ProjectId},
     anyhow::Context as _,
     async_trait::async_trait,
 };
@@ -9,13 +9,13 @@ const TTL_SECS: usize = 300;
 
 #[async_trait]
 impl Cache for redis::Adapter {
-    async fn set_data(&self, project_id: &str, data: &Option<ProjectData>) -> Result<()> {
+    async fn set_data(&self, project_id: ProjectId, data: &Option<ProjectData>) -> Result<()> {
         let bytes = cache::serialize_data(data).context("Failed to serialize ProjectData")?;
-        self.set_ex(project_id, bytes, TTL_SECS).await
+        self.set_ex(project_id.as_ref(), bytes, TTL_SECS).await
     }
 
-    async fn get_data(&self, project_id: &str) -> Result<Output> {
-        let output: Option<Vec<u8>> = self.get(project_id).await?;
+    async fn get_data(&self, project_id: ProjectId) -> Result<Output> {
+        let output: Option<Vec<u8>> = self.get(project_id.as_ref()).await?;
         Ok(match output {
             Some(bytes) => cache::deserialize_data(bytes.as_slice())
                 .map(Output::Hit)

--- a/src/project_registry/cloud.rs
+++ b/src/project_registry/cloud.rs
@@ -1,6 +1,6 @@
 use {
     super::{ProjectData, ProjectRegistry, Result},
-    crate::Domain,
+    crate::{Domain, ProjectId},
     async_trait::async_trait,
     cerberus::registry::{RegistryClient, RegistryHttpClient},
     metrics::counter,
@@ -17,8 +17,8 @@ pub fn new(base_url: impl Into<String>, auth_token: &str) -> Result<impl Project
 
 #[async_trait]
 impl ProjectRegistry for RegistryHttpClient {
-    async fn project_data(&self, id: &str) -> Result<Option<ProjectData>> {
-        let data = RegistryClient::project_data(self, id)
+    async fn project_data(&self, id: ProjectId) -> Result<Option<ProjectData>> {
+        let data = RegistryClient::project_data(self, id.as_ref())
             .await
             .tap(|_| counter!("project_registry_requests", 1))
             .tap_err(|_| counter!("project_registry_errors", 1))?;

--- a/src/project_registry/mod.rs
+++ b/src/project_registry/mod.rs
@@ -3,11 +3,11 @@ pub mod cloud;
 
 pub use cache::{Cache, Cached, CachedExt};
 
-use crate::{async_trait, ProjectData};
+use crate::{async_trait, ProjectData, ProjectId};
 
 #[async_trait]
 pub trait ProjectRegistry: Send + Sync + 'static {
-    async fn project_data(&self, id: &str) -> Result<Option<ProjectData>>;
+    async fn project_data(&self, id: ProjectId) -> Result<Option<ProjectData>>;
 }
 
 pub type Error = anyhow::Error;


### PR DESCRIPTION
# Description

Resolves #33

Currently the project IDs provided to `GET /:project_id` are not validated, which causes `500` s on invalid ones because we are passing some junk strings into the `ProjectRegistry`

## How Has This Been Tested?

Integration

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update