### PR TITLE
feat: Temporary disable Content-Security-Policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bouncer"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -60,16 +60,16 @@ describe('verify', () => {
 
       expect(resp.status).toBe(200)
 
-      let policy = resp.headers["content-security-policy"]
+      // let policy = resp.headers["content-security-policy"]
 
-      if (ENV === 'prod') {
-        expect(policy).toBe("frame-ancestors https://*.walletconnect.com")
-      } else {
-        let wc = "https://*.walletconnect.com https://walletconnect.com"
-        let vercel = "https://*.vercel.app https://vercel.app"
-        let localhost = "http://*.localhost http://localhost"
-        expect(policy).toBe(`frame-ancestors ${wc} ${wc} ${vercel} ${localhost}`)
-      }
+      // if (ENV === 'prod') {
+      //   expect(policy).toBe("frame-ancestors https://*.walletconnect.com")
+      // } else {
+      //   let wc = "https://*.walletconnect.com https://walletconnect.com"
+      //   let vercel = "https://*.vercel.app https://vercel.app"
+      //   let localhost = "http://*.localhost http://localhost"
+      //   expect(policy).toBe(`frame-ancestors ${wc} ${wc} ${vercel} ${localhost}`)
+      // }
     })
 
     it('non-existent project', async () => {
@@ -79,19 +79,20 @@ describe('verify', () => {
     })
 
     it('project without a verified domain', async () => {
-      let resp = await http.get(`${url}/22f5c861aeb01d5928e9f347df79f21b`)
+      let resp = await http.get(`${url}/22f5c861aeb01d5928e9f347df79f21b`)      
+      expect(resp.status).toBe(200)
 
-      if (ENV === 'prod') {
-        expect(resp.status).toBe(404)
-        expect(resp.data).toContain("Project with the provided ID doesn't have a verified domain")
-      } else {
-        let policy = resp.headers["content-security-policy"]
+      // if (ENV === 'prod') {
+      //   expect(resp.status).toBe(404)
+      //   expect(resp.data).toContain("Project with the provided ID doesn't have a verified domain")
+      // } else {
+      //   let policy = resp.headers["content-security-policy"]
 
-        let wc = "https://*.walletconnect.com https://walletconnect.com"
-        let vercel = "https://*.vercel.app https://vercel.app"
-        let localhost = "http://*.localhost http://localhost"
-        expect(policy).toBe(`frame-ancestors ${wc} ${vercel} ${localhost}`)
-      }
+      //   let wc = "https://*.walletconnect.com https://walletconnect.com"
+      //   let vercel = "https://*.vercel.app https://vercel.app"
+      //   let localhost = "http://*.localhost http://localhost"
+      //   expect(policy).toBe(`frame-ancestors ${wc} ${vercel} ${localhost}`)
+      // }
     })
   })
   describe('index.js', () => {

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -95,12 +95,13 @@ pub async fn root(
         return Err((StatusCode::NOT_FOUND, NO_VERIFIED_DOMAINS_MSG).into_response());
     }
 
-    let headers = [(
+    // TODO: enable once clients are ready
+    let _headers = [(
         header::CONTENT_SECURITY_POLICY,
         build_content_security_header(domains),
     )];
 
-    Ok((headers, Html(INDEX_HTML)))
+    Ok(Html(INDEX_HTML))
 }
 
 impl From<GetAllowedDomainsError> for Response {


### PR DESCRIPTION
# Description

Turns out our SDKs are not ready for the feature yet.

## How Has This Been Tested?

Integration

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update