### PR TITLE
fix(terraform): update hashicorp/aws version

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.51"
+      version = ">= 5.0.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = var.region
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.51"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
# Description

`terraform init` no longer works on the pipeline. Seems like some dependency now requires `aws >= 5.0.0`

## How Has This Been Tested?

Locally, `terraform init` works

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update