### PR TITLE
feat: send message to parent page on load

### DIFF
--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -29,6 +29,9 @@ window.addEventListener("load", async () => {
         window.location.reload()
     }, 60_000)
 })
+
+// notify the SDK that the iframe is ready
+window.parent.postMessage("verify_ready")
 "#;
 
 #[derive(Deserialize)]


### PR DESCRIPTION
# Description
Served JS now sends a message to the parent page notifying the SDK that the iframe has loaded instead of relying on `onload/onerror` events


## How Has This Been Tested?
dogfooding

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update