### PR TITLE
fix: sanitize /index.js?token parameter

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -158,5 +158,10 @@ describe('verify', () => {
       resp = await http.get(`${url}/index.js?token=${csrfToken}`)
       expect(resp.status).toBe(200)
     })
+
+    it('doesn\'t allow invalid `token` parameters', async () => {
+      let resp = await http.get(`${url}/index.js?token=<img src onerror=alert(document.domain)>`)
+      expect(resp.status).toBe(400)
+    })
   })
 })

--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -1,8 +1,10 @@
 use {
+    super::CsrfToken,
     axum::{
         extract::Query,
         response::{Html, IntoResponse},
     },
+    hyper::StatusCode,
     serde::Deserialize,
 };
 
@@ -39,6 +41,10 @@ pub(super) struct Params {
     token: String,
 }
 
-pub(super) async fn get(query: Query<Params>) -> impl IntoResponse {
-    Html(TEMPLATE.replacen("{token}", &query.token, 1))
+pub(super) async fn get(query: Query<Params>) -> Result<impl IntoResponse, StatusCode> {
+    if !CsrfToken::validate_format(&query.token) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    Ok(Html(TEMPLATE.replacen("{token}", &query.token, 1)))
 }

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -143,6 +143,12 @@ impl CsrfToken {
     const fn header_name() -> HeaderName {
         HeaderName::from_static("x-csrf-token")
     }
+
+    /// Validates the format of the token without checking either signature or
+    /// claims.
+    fn validate_format(s: &str) -> bool {
+        jsonwebtoken::decode_header(s).is_ok()
+    }
 }
 
 impl<B> Server<B> {


### PR DESCRIPTION
# Description

`token` parameter wasn't being sanitized, allowing JS injection.
This should not have affected the service invariants, as the url is only being built by the `bouncer` itself.


## How Has This Been Tested?

Integration

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update